### PR TITLE
better bindings

### DIFF
--- a/bindings.rs
+++ b/bindings.rs
@@ -22,25 +22,26 @@ fn main() {
         let path_out = PathBuf::from(env::var("OUT_DIR").unwrap());
         let path_bindings = path_out.join(BINDINGS);
 
-        if !path_bindings.exists() {
-            PkgConfig::new()
-                .probe("xmlsec1")
-                .expect("Could not find xmlsec1 using pkg-config");
+        PkgConfig::new()
+            .probe("xmlsec1")
+            .expect("Could not find xmlsec1 using pkg-config");
 
-            let bindbuild = BindgenBuilder::default()
-                .header("bindings.h")
-                .clang_args(fetch_xmlsec_config_flags())
-                .clang_args(fetch_xmlsec_config_libs())
-                .layout_tests(false)
-                .rustfmt_bindings(true)
-                .generate_comments(true);
+        let bindbuild = BindgenBuilder::default()
+            .header("bindings.h")
+            .clang_args(fetch_xmlsec_config_flags())
+            .clang_args(fetch_xmlsec_config_libs())
+            .allowlist_function("xmlSec.*")
+            .allowlist_type("xmlSec.*")
+            .allowlist_var("xmlSec.*")
+            .layout_tests(true)
+            .rustfmt_bindings(true)
+            .generate_comments(true);
 
-            let bindings = bindbuild.generate().expect("Unable to generate bindings");
+        let bindings = bindbuild.generate().expect("Unable to generate bindings");
 
-            bindings
-                .write_to_file(path_bindings)
-                .expect("Couldn't write bindings!");
-        }
+        bindings
+            .write_to_file(path_bindings)
+            .expect("Couldn't write bindings!");
     }
 }
 

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -6,6 +6,7 @@
 #![allow(non_camel_case_types)]
 #![allow(non_upper_case_globals)]
 #![allow(improper_ctypes)]
+#![allow(deref_nullptr)]
 #![allow(clippy::upper_case_acronyms)]
 
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));


### PR DESCRIPTION
- Do not derive Ord, PartialOrd and Hash when it is useless
- Limit bindings to xmlSec specific entities
