### PR TITLE
xmlsec

### DIFF
--- a/bindings.h
+++ b/bindings.h
@@ -3,6 +3,7 @@
 //
 #include <xmlsec/app.h>
 #include <xmlsec/crypto.h>
+#include <xmlsec/errors.h>
 #include <xmlsec/keys.h>
 #include <xmlsec/openssl/app.h>
 #include <xmlsec/openssl/crypto.h>

--- a/bindings.rs
+++ b/bindings.rs
@@ -18,6 +18,7 @@ fn main() {
         println!("cargo:rustc-link-lib=xml2"); // -lxml2
         println!("cargo:rustc-link-lib=ssl"); // -lssl
         println!("cargo:rustc-link-lib=crypto"); // -lcrypto
+        println!("cargo:rerun-if-changed=bindings.h");
 
         let path_out = PathBuf::from(env::var("OUT_DIR").unwrap());
         let path_bindings = path_out.join(BINDINGS);

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -14,13 +14,13 @@ use std::convert::TryInto;
 use std::ffi::CString;
 
 #[cfg(feature = "xmlsec")]
-const XMLNS_XML_DSIG: &str = "http://www.w3.org/2000/09/xmldsig#";
+pub const XMLNS_XML_DSIG: &str = "http://www.w3.org/2000/09/xmldsig#";
 #[cfg(feature = "xmlsec")]
-const XMLNS_SIGVER: &str = "urn:urn-5:08Z8lPlI4JVjifINTfCtfelirUo";
+pub const XMLNS_SIGVER: &str = "urn:urn-5:08Z8lPlI4JVjifINTfCtfelirUo";
 #[cfg(feature = "xmlsec")]
-const ATTRIB_SIGVER: &str = "sv";
+pub const ATTRIB_SIGVER: &str = "sv";
 #[cfg(feature = "xmlsec")]
-const VALUE_SIGVER: &str = "verified";
+pub const VALUE_SIGVER: &str = "verified";
 
 #[derive(Debug, Snafu)]
 pub enum Error {

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,6 +1,8 @@
 use snafu::Snafu;
 
 #[cfg(feature = "xmlsec")]
+pub use crate::xmlsec::enable_tty_error_output as enable_xmlsec_tty_error_output;
+#[cfg(feature = "xmlsec")]
 use crate::xmlsec::{self, XmlSecKey, XmlSecKeyFormat, XmlSecSignatureContext};
 #[cfg(feature = "xmlsec")]
 use libxml::parser::Parser as XmlParser;

--- a/src/xmlsec/mod.rs
+++ b/src/xmlsec/mod.rs
@@ -26,4 +26,4 @@ pub use self::error::XmlSecResult;
 pub use self::keys::XmlSecKey;
 pub use self::keys::XmlSecKeyFormat;
 pub use self::xmldsig::XmlSecSignatureContext;
-pub use self::xmlsec::XmlSecContext;
+pub use self::xmlsec::{enable_tty_error_output, XmlSecContext};

--- a/src/xmlsec/xmlsec.rs
+++ b/src/xmlsec/xmlsec.rs
@@ -46,6 +46,8 @@ impl XmlSecContext {
         init_crypto_app()?;
         init_crypto()?;
 
+        enable_tty_error_output(false);
+
         Ok(Self {})
     }
 }
@@ -106,4 +108,13 @@ fn cleanup_crypto_app() {
 /// Shutdown xmlsec library
 fn cleanup_xmlsec() {
     unsafe { bindings::xmlSecShutdown() };
+}
+
+/// When using the default error callback of the xmlsec library, enable the error output on the
+/// TTY. By defaut, output is disabled when we start using xmlsec, it can later be reenabled
+/// using this function.
+pub fn enable_tty_error_output(enabled: bool) {
+    unsafe {
+        bindings::xmlSecErrorsDefaultCallbackEnableOutput(enabled as std::os::raw::c_int);
+    }
 }


### PR DESCRIPTION
- Silence xmlsec errors on tty by default
- Make some entities public so that they can be used in documentation
